### PR TITLE
Fix audio downloading path in ActiveJob.

### DIFF
--- a/app/jobs/file_processing_job.rb
+++ b/app/jobs/file_processing_job.rb
@@ -22,7 +22,7 @@ class FileProcessingJob < ApplicationJob
                             @processed_file.voice)
       logger.info("Created audio file: #{audio_file}")
 
-      @processed_file.audio_file.attach(io: File.open(Rails.root.join(audio_file)), filename: File.basename(audio_file))
+      @processed_file.audio_file.attach(io: File.open(audio_file), filename: File.basename(audio_file))
       FileUtils.rm_f(audio_file)
 
     rescue StandardError => e


### PR DESCRIPTION
We cannot access `Rails.root` in an ActiveJob, at least not if run via Sidekiq, because it runs in a different Docker container than the Rails app and we have no shared directories mapped between the 2 Dockers via e.g. volumes.
When run as in-memory Job queue, this might be different.

Furthermore, we don't need to share any directories here, because the audio file is only needed temporarily unless attached via ActiveStorage. Therefore, we can use the systems temp directory for temporary storage.